### PR TITLE
Fix missing app dependency for service course.

### DIFF
--- a/course/steps/00-services/en.md
+++ b/course/steps/00-services/en.md
@@ -2,18 +2,20 @@
 
 ## Introduction
 
-The VTEX IO platform allows developers to create unique commerce experiences using Web technologies. It’s possible to create frontend blocks for Store Framework, backend services exposing REST or GraphQL APIs and combine a series of VTEX modules into a complete solution, packaging it into an app.
+The VTEX IO platform allows developers to create unique commerce experiences using Web technologies. It’s possible to create frontend blocks for Store Framework, backend services exposing REST or GraphQL APIs, and combine a series of VTEX modules into a complete solution, packaging it into an app.
 
 As VTEX IO powers big e-commerce operations, they require **running code on a server**. **Services** are how we run **Node.js or .NET** code on VTEX IO infrastructure, backed by API abstractions to improve developer experience.
 
 ## Setting up our test bot
-It's important for you to have out test bot installed in this course repository so as for us to see your progress, even though it does not contains any tests or evaluation on each step. So as to install it, follow the steps below:
+It's important for you to have our test bot installed in this course repository. With it installed, we can see your progress, even though it does not contain any tests or evaluations on each step (as in other courses we offer). To install it, follow the steps below:
 
 1. Open [our test bot installation page](https://github.com/apps/vtex-course-hub) and click on **Configure**;
-2. Select the **Only selected repositories** option, then click on **Select repositories** and type in `store-block`;
-3. Click on `{{ user.username }}/store-block` and then on **Install**.
+2. Select the **Only selected repositories** option, then click on **Select repositories** and type in `service-course`;
+3. Click on `{{ user.username }}/service-course` and then on **Install**. 
 
     <img src="https://user-images.githubusercontent.com/19495917/86020968-f31fca00-b9fe-11ea-9776-ccab355663b5.png" width="350" />
+
+    > **Note:** The image above shows the process for `store-block`, but the steps for `service-course` are the same.
 
 ## Services
 

--- a/course/steps/00-services/en.md
+++ b/course/steps/00-services/en.md
@@ -23,6 +23,6 @@ A **Service** must be exported from a VTEX IO app, just like themes or store blo
 
 Services in VTEX IO support one-command rollbacks and continuous integration. They can export internal and external routes and run on top of Kubernetes. You can count on VTEX IO to manage the scalability of your services.
 
-On the `/node` folder of a service lives `service.json`, where it´s possible to **declare routes that the service must respond to** and other configurations like _timeout_ and _memory_.
+Inside the `/node` folder of a service lives `service.json`, where it´s possible to **declare routes that the service must respond to** and other configurations like _timeout_ and _memory_.
 
 During this course, you will implement some services in VTEX IO and learn a bit more about the possibilities that they offer to your development.

--- a/course/steps/01-boilerplate/en.md
+++ b/course/steps/01-boilerplate/en.md
@@ -8,7 +8,7 @@ Making a brief overview of the _Boilerplate_, there are two directories (`/node`
 
 In the `manifest.json` file, you will find the app's name, vendor, version, and other information to pay attention to: builders, policies and dependencies. In this initial state, we have the following configurations:
 
-- builders: what builders your app will need. In this case, we have, so far, only the `docs builder` and the `node builder`, with their respective versions;
+- builders: what builders your app will need. In this case, we currently only have the `node` builder, with its respective version;
 - policies: if the app being built needs to access some external services or get some specific data from other places, it needs to declare so, even for external APIs. At this point, we have no specific policies yet;
 - dependencies: other VTEX IO apps your app depends on. As addressed below, for this course, we need to also link the `events-example` app, as it is listed as a dependency for this course app.
 
@@ -22,9 +22,10 @@ All directories used over the course are already in this initial project. Most o
 
 - `/node/utils`: you will find a file containing global constants declarations (`/node/constants.ts`).
 
-- `/node/index.ts`: contains the initial declarations for the app functionality like the cache declaration and the service declarations, which will be incremented during the course. Here is also possible to export resolver functions implementations.
+- `/node/index.ts`: contains the initial declarations for the app functionality like the cache declaration and the service declarations, which will be incremented during the course. Here it is also possible to export resolver functions implementations (for GraphQL).
 
-- `/node/service.json`: It describes your REST API and some characteristics that will directly impact your app's infrastructure attributes.
+- `/node/service.json`: describes your REST API and some characteristics that will directly impact your app's infrastructure attributes.
+
   Your service.json file will be found inside your app's `/node` folder, and will look similar to this:
 
   ```
@@ -47,7 +48,7 @@ All directories used over the course are already in this initial project. Most o
   | timeout     | Seconds    | VTEX.IO infra will abort the connection if the request time is longer than timeout                                               |
   | minReplicas | Integer    | When your app is running, how many minimum replicas will be available                                                            |
   | maxReplicas | Integer    | The largest amount of replicas that will be available                                                                            |
-  | routes      | -          | Describes your app's REST routes, inside you will descibe the name, (ex: ssr), the path, and if its public or private            |
+  | routes      | -          | Describes your app's REST routes, inside you will describe the name, (ex: ssr), the path, and if it's public or private            |
 
 ## `/graphql` Directory Overview
 
@@ -55,7 +56,7 @@ On this directory, you will find only the empty directories and the `/graphql/sc
 
 ## Dependencies
 
-For this course, this app has a dependency on the `events-example` app. The `events-example` app, when linked to your account and workspace, is responsable for providing events examples. Over the course, as we approach the events topic, there will be a more complete overview of the `events-example` app.
+For this course, this app has a dependency on the `events-example` app. The `events-example` app, when linked to your account and workspace, is responsable for providing events examples. Over the course, as we approach the events topic, there will be a more complete overview of the `events-example` app. 
 
 ## Activity
 

--- a/course/steps/02-events/en.md
+++ b/course/steps/02-events/en.md
@@ -21,7 +21,7 @@ On VTEX IO apps, events can be fired and used to trigger actions. For example, a
    ```diff
    //node/index/ts
 
-   + const TREE_SECONDS_MS = 3 * 1000
+   + const THREE_SECONDS_MS = 3 * 1000
    + const CONCURRENCY = 10
 
    export default new Service<Clients, State, ParamsContext>({
@@ -37,7 +37,7 @@ On VTEX IO apps, events can be fired and used to trigger actions. For example, a
    +        exponentialBackoffCoefficient: 2,
    +        initialBackoffDelay: 50,
    +        retries: 1,
-   +        timeout: TREE_SECONDS_MS,
+   +        timeout: THREE_SECONDS_MS,
    +        concurrency: CONCURRENCY,
    +      },
    +    },

--- a/course/steps/03-clients-analytics/en.md
+++ b/course/steps/03-clients-analytics/en.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-In this step, some clients concepts are going to be briefly explained and it's presented which are the clients that are necessary for this course: **analytics client** and **master data client**. The first one will be implemented on this step and you'll also learn how to use a client that has been already implemented in our API.
+In this step, we briefly explain some clients concepts and present the clients that will be necessary for this course: **analytics client** and **master data client**. The first one will be implemented on this step, and you'll also learn how to use a client that has been already implemented in our API.
 
 ## About the clients
 
@@ -18,23 +18,24 @@ In this course, it will be necessary to create a client that will be used to get
 
 ## Activity
 
-In this step, we will implement the Anaylitcs client. So,
+In this step, we will implement the Analytics client. So,
 
 1. First, in the `/node/clients/` directory, you will find a file called `analytics.ts`, which already has a sketch, just like the code block below. This is where you'll implement your client.
 
    ```ts
+   //node/clients/analytics.ts
    import { AppClient } from '@vtex/api'
 
    export default class Analytics extends AppClient {}
    ```
 
-   > You can noticed in this code block that Analytics is a client that extends from `AppClient` because this offers pre-configurations that assure that your client has a secure communication with other parts of your app.
+   > You can see in this code block that `Analytics` is a client that extends from `AppClient` because this class offers pre-configurations that assure that your client has secure communication with other parts of your app.
 
 2. The client needs to have a constructor and just a single method, called `getLiveUsers`. This method returns a promise of an array that its elements are of the type `LiveUsersProduct`. Using the code below, add the necessary code lines to the client:
 
    ```diff
    //node/clients/analytics.ts
-   import { AppClient, InstanceOptions, IOContext } from '@vtex/api'
+   +import { AppClient, InstanceOptions, IOContext } from '@vtex/api'
 
    export default class Analytics extends AppClient {
    +  constructor(context: IOContext, options?: InstanceOptions) {
@@ -60,7 +61,14 @@ In this step, we will implement the Anaylitcs client. So,
 
    > The method that you've just created will get the necessary data for this application: an array of objects that have two fields: `slug`, a string that represents the product ID and `liveUsers`, a number that is the quantity of users visualizing this product - which are the fields in the interface.
 
-4. With your analytics client already implemented, it's necessary to declare it as one of the clients in the `Clients` class, so it will be accessible using the `Context` that we've talked about at the beginning of this step.
+4. The `_v/live-products` API endpoint we call above needs the app `mocked-analytics` to run, or your `getLiveUsers` method will not see anything there. Clone a copy of the [`mocked-analytics` repository](https://github.com/vtex-apps/mocked-analytics/) locally. 
+
+   As with `events-example` before, you'll need to link this app to your workspace. From your local `mocked-analytics` directory, run  
+   ```
+   vtex link
+   ```
+
+5. With your analytics client already implemented, it's necessary to declare it as one of the clients in the `Clients` class, so it will be accessible using the `Context` that we've talked about at the beginning of this step.
 
    So, in the `node/clients/` directory, go to the file called `index.ts` and add a get method to the class that refers to the analytics client. It's also necessary to import the client that you created.
 
@@ -75,7 +83,7 @@ In this step, we will implement the Anaylitcs client. So,
    }
    ```
 
-5. So as to see it working, it's possible to use `getLiveUsers` method inside the handler for the analytics client. Using a route that it's already defined in the project, it is possible to send a request to it and the handler responsible for this route will call the method that we created.
+6. So as to see it working, it's possible to use `getLiveUsers` method inside the handler for the analytics client. Using a route that it's already defined in the project, it is possible to send a request to it and the handler responsible for this route will call the method that we created.
 
    Inside the node directory, there is a folder called `handlers`. There is already a file named `analytics.ts`, in which its necessary to do two things for your test to work: get the analytics client from `ctx` and replace the content of `ctx.body` with the method mentioned before, as you can see in the code block below:
 
@@ -92,9 +100,9 @@ In this step, we will implement the Anaylitcs client. So,
     }
   ```
 
-6. Now let's test it! It's possible to use Postman to send a `GET` request to the following route:
+7. Now let's test it! It's possible to use Postman to send a `GET` request to the following route:
 
-   `{your workspace}--appliancetheme.myvtex.com/_v/app/analytics/realTime`
+   `{your workspace}--{your account}.myvtex.com/_v/app/analytics/realTime`
 
    and it's expected that it replies with the data and status `200`.
 

--- a/course/template/.gitignore
+++ b/course/template/.gitignore
@@ -1,0 +1,2 @@
+# Add this here because the vtex link step runs yarn and adds 5000+ files
+node_modules/

--- a/course/template/node/handlers/analytics.ts
+++ b/course/template/node/handlers/analytics.ts
@@ -1,9 +1,7 @@
 export async function analytics(ctx: Context, next: () => Promise<any>) {
-  if (ctx.method.toUpperCase() === 'GET') {
-    ctx.status = 200
-    ctx.body = 'OK'
+  ctx.status = 200
+  ctx.body = 'OK'
 
-    ctx.set('cache-control', 'no-cache')
-  }
+  ctx.set('cache-control', 'no-cache')
   await next()
 }


### PR DESCRIPTION
Hello! This is my first PR for a GitHub project, so please let me know if I have done this the wrong way. :) 

I was unable to get the `_v/live-products` API endpoint working until I linked the `mocked-analytics` app, so I added that to the instructions in the steps, and fixed a few typos in the English translation.

----
Olá! Este é o meu primeiro PR para um projeto GitHub, então, deixe-me saber se eu fiz isso da maneira errada. :)

Eu não consegui fazer com que o terminal da API `_v / live-products` funcionasse até vincular o aplicativo` mocked-analytics`, então acrescentei isso às instruções das etapas e corrigi alguns erros de digitação na tradução em inglês.

> _O texto acima foi traduzido no Google Translate._